### PR TITLE
Support plasp 3.1

### DIFF
--- a/encodings/planner/runplanner.py
+++ b/encodings/planner/runplanner.py
@@ -3,7 +3,7 @@ import sys
 import os
 import argparse
 
-PLASP         = "plasp"
+PLASP         = "plasp translate --parsing-mode=compatibility"
 PLASP_DIR     = os.path.dirname(os.path.realpath(__file__)) + "/../../"
 PLANNER       = PLASP_DIR + "encodings/planner/planner.py"
 BASIC         = PLASP_DIR + "encodings/planner/basic.lp"


### PR DESCRIPTION
`plasp`’s command line changed with 3.1. This commit makes the planner compatible with this change.