### PR TITLE
Support Python 3

### DIFF
--- a/encodings/planner/runplanner.py
+++ b/encodings/planner/runplanner.py
@@ -148,7 +148,7 @@ def run():
             domain = os.path.dirname(os.path.realpath(instance)) + "/../domain.pddl"
 
     if not os.path.isfile(domain):
-        print "Domain File not found"
+        print("Domain File not found")
         return
 
     #
@@ -284,7 +284,7 @@ def run():
     #
 
     if options['print']:
-        print call
+        print(call)
     else:
         os.system(call)
 


### PR DESCRIPTION
Just because of the print function usage, the planner is incompatible with Python 3. This commit sets the necessary parentheses, with which the planner works for both Python 2 and Python 3.

Please note that [Python 2 will reach end of life in about 2 years](https://pythonclock.org/).