### PR TITLE
Fix hard-coded paths to Fast Downward

### DIFF
--- a/encodings/planner/runplanner.py
+++ b/encodings/planner/runplanner.py
@@ -43,8 +43,8 @@ TEST_ACT_T    = os.path.join(TEST_FILES,"block_actions_t.lp")
 
 # Other systems
 CLINGO      = "clingo"
-FAST_D      = "/home/wv/bin/linux/64/fast-downward-data/fast-downward.py --alias seq-sat-lama-2011"
-FAST_D_TR   = "/home/wv/bin/linux/64/fast-downward-data/fast-downward.py --translate"
+FAST_D      = "/home/wv/bin/linux/64/fast-downward/fast-downward.py --alias seq-sat-lama-2011"
+FAST_D_TR   = "/home/wv/bin/linux/64/fast-downward/fast-downward.py --translate"
 SAS_OUTPUT  = "output.sas"
 M           = "M"
 MP          = "Mp"


### PR DESCRIPTION
I recently adjusted `/home/wv/bin/linux/64/fast-downward/` to be a symbolic link pointing to the most recent deployed version of Fast Downward for easier maintenance.

Even though hard-coded paths aren’t a good solution, this fixed the paths to Fast Downward for the time being. A much better solution would be a config.example.py that can be customized by the users to a config.py and that is read by the planner. However, I don’t have the resources to help with a real fix right now 🙂.