### PR TITLE
Remove infinite timeout in conditional wait

### DIFF
--- a/encodings/planner/clingo_signal_handler.py
+++ b/encodings/planner/clingo_signal_handler.py
@@ -129,7 +129,7 @@ class ClingoSignalHandler:
             with control.solve(
                 async=True, on_finish=self.stop, *args, **kwargs
             ) as handle:
-                self.condition.wait(float("inf"))
+                self.condition.wait()
                 handle.wait()
 
     # public


### PR DESCRIPTION
The `timeout` argument to [`Condition.wait()`](https://docs.python.org/3/library/threading.html#threading.Condition.wait) is optional. If omitted, the method will block without a time limit, which very likely is what was intended by using an infinite timeout in the first place.

This fixes issues with Python 3, where a timeout of infinity makes the method block forever. This behavior is different from Python 2 but seems not to be documented in the official Python documentation.

I tested that running the planner with Python 2 still works as before.