### PR TITLE
Fix Condition.wait() for Python 2 and Python 3

### DIFF
--- a/encodings/planner/clingo_signal_handler.py
+++ b/encodings/planner/clingo_signal_handler.py
@@ -129,7 +129,11 @@ class ClingoSignalHandler:
             with control.solve(
                 async=True, on_finish=self.stop, *args, **kwargs
             ) as handle:
-                self.condition.wait()
+                # In Python 2, Condition.wait() isn't interruptible when called without a timeout.
+                # In Python 3, infinite timeouts lead to overflow errors.
+                # To accomodate for both Python versions, a switch on the timeout is necessary.
+                # More information available at: https://bugs.python.org/issue8844
+                self.condition.wait(timeout = float("inf") if sys.version_info[0] < 3 else None)
                 handle.wait()
 
     # public


### PR DESCRIPTION
`Condition.wait()` internally acquires a lock. For some reason, this method is not interruptible in Python 2 if `Condition.wait()` is called without a timeout.

The implementation of threading in Python 3 is completely different and makes `Condition.wait()` interruptible. Also, an infinite timeout leads to overflow issues.

For more information, see the [Python bugtracker discussion](https://bugs.python.org/issue8844).

Because there is no single solution to make the condition variable work in both Python 2 and 3, this adds a switch to the timeout option depending on the Python version.